### PR TITLE
Added Features - Selling/Transfer of Shares

### DIFF
--- a/contract.sol
+++ b/contract.sol
@@ -12,8 +12,6 @@ contract Company {
     
     string[] public articles;
     
-    modifier onlyowner { if (msg.sender == owner) _ }
-    
     struct CompanyIdentity {
         string name;
         uint creationTime;
@@ -27,6 +25,8 @@ contract Company {
     }
     struct ShareTypeOwnership {
         uint sharesOwned;
+        uint sharesForSale;
+        uint shareSalePrice;
     }
         //Voting["NewSharePrice"][500] = 
     struct Voting {
@@ -42,11 +42,101 @@ contract Company {
         mapping(uint => VotesFor) subject;
     }
     
-    
     //votingFor["newShareValue"].subject[newValue].sharesVotingFor;
     CompanyIdentity public companyId;
     ShareOwner[] shareOwnership;
     mapping (string => Voting) votingFor;
+    
+    modifier onlyowner { if (msg.sender == owner) _ }
+    
+    modifier onlyShareholder { 
+        if (checkIfAlreadyOwner(msg.sender) <= shareOwnership.length && 
+        shareOwnership.length > 0) _
+    }
+    
+    function setSharesForSale(uint _amt, uint _price, string _unit, bool _isCommon) onlyShareholder {
+        //Turn this into a modifier for optimization
+        uint _ownerIndex = checkIfAlreadyOwner(msg.sender);
+        
+        uint _sellerShares = shareOwnership[_ownerIndex].isCommonShare[_isCommon].sharesOwned;
+        uint _ownersSharesForSale = shareOwnership[_ownerIndex].isCommonShare[_isCommon].sharesForSale;
+        
+        //check owner has enough shares to sell
+        if (_sellerShares == 0 || (_sellerShares - _ownersSharesForSale) < _amt)
+            throw;
+        
+        uint _newValue = _price * currencyCheck(_unit);
+        
+        //shareOwnership[_ownerIndex].isCommonShare[_isCommon].sharesForSale = _amt;
+        shareOwnership[_ownerIndex].isCommonShare[_isCommon].sharesForSale = _amt;
+        shareOwnership[_ownerIndex].isCommonShare[_isCommon].shareSalePrice = _newValue;
+        
+        //Remove shareholders votes once trade executed
+    }
+    
+    //price must be included to ensure buyer gets the shares for price they are expecting
+    function buySharesFrom(string _buyerName,
+        address _sellerAddress, 
+        uint _amt, uint _price, 
+        string _unit, 
+        bool _isCommon) 
+    {
+        
+        uint _sellerIndex = checkIfAlreadyOwner(_sellerAddress);
+        uint _formattedPrice = _price * currencyCheck(_unit);
+        uint _transactionValue = _amt * _formattedPrice;
+        ShareTypeOwnership _sellerShortcut = shareOwnership[_sellerIndex].isCommonShare[_isCommon];
+        
+        //Check if shares of type are for sale by this seller at requested price
+        if (_sellerShortcut.sharesForSale < _amt || 
+        _sellerShortcut.shareSalePrice != _formattedPrice ||
+        msg.value < _transactionValue)
+            throw;
+            
+        //Exchange approved, add buyer to owners if needed.
+        uint _buyerIndex = checkIfAlreadyOwner(msg.sender);
+        if (_buyerIndex > shareOwnership.length)
+            shareOwnership.push(ShareOwner(msg.sender, _buyerName));
+        
+        //ORDER MAY BE IMPORTANT HERE, TEST!!!!!
+        shareOwnership[_sellerIndex].isCommonShare[_isCommon].sharesForSale -= _amt;
+        shareOwnership[_sellerIndex].isCommonShare[_isCommon].sharesOwned -= _amt;
+        //IF THESE WERE COMMON SHARES, MUST REMOVE ANY VOTES THEY ARE AFFECTING, INCLUDING SHARE REVOCATION
+        if (_isCommon)
+            delete votingFor["newShareValue"].ownerAddress[_sellerAddress];
+        //Need to debug, in case there's multiple calls at same time, there may be collisions between buyers
+        shareOwnership[_buyerIndex].isCommonShare[_isCommon].sharesOwned += _amt;
+        
+        //After shares change hands, send funds
+        _sellerAddress.send(_transactionValue);
+        //Refund any remainder back to buyer
+        msg.sender.send(msg.value - _transactionValue);
+
+            
+    }
+    
+    function transferShares (address _receiver, uint _amt, bool _isCommon) onlyShareholder {
+        uint _senderIndex = checkIfAlreadyOwner(msg.sender);
+        
+        uint _receiverIndex = checkIfAlreadyOwner(_receiver);
+        if (_receiverIndex > shareOwnership.length)
+            shareOwnership.push(ShareOwner(_receiver, ""));
+            
+        //Ensure the shares being sent aren't for sale on market already, to avoid transferring shares while still
+        //having them on the exchange
+        uint _sharesForSale = shareOwnership[_senderIndex].isCommonShare[_isCommon].sharesForSale;
+        uint _sharesOwned = shareOwnership[_senderIndex].isCommonShare[_isCommon].sharesOwned;
+        if (_sharesOwned - _sharesForSale < _amt)
+            throw;
+        
+        shareOwnership[_senderIndex].isCommonShare[_isCommon].sharesForSale -= _amt;
+        shareOwnership[_senderIndex].isCommonShare[_isCommon].sharesOwned -= _amt;
+        
+        if (_isCommon)
+            delete votingFor["newShareValue"].ownerAddress[msg.sender];
+            
+        shareOwnership[_receiverIndex].isCommonShare[_isCommon].sharesOwned += _amt;
+    }
     
     function Company() {
         owner = msg.sender;
@@ -111,7 +201,7 @@ contract Company {
         _sharesForRevocation += _revokerShares;
         
         
-        //Vote
+        //Fix double voting
         if ((_sharesForRevocation * 100) / commonShares >= majority) {
             //clear any votes for shares to be removed at this amount or higher, in case this owner is issued more common shares
             for (uint i = _numSharesToRemove; i <= _ownerShares; i++) {
@@ -144,6 +234,36 @@ contract Company {
         }
     }
     
+    function getSharesForSale(address _sellerAddress) constant returns (
+        string _ownerName, 
+        uint _commonSharesSelling,
+        uint _commonSharesPrice,
+        string _commonSharePriceUnits,
+        uint _preferredSharesSelling,
+        uint _preferredSharesPrice,
+        string _preferredSharePriceUnits)
+    {
+        uint _sellerIndex = checkIfAlreadyOwner(_sellerAddress);
+        
+        _ownerName = shareOwnership[_sellerIndex].ownerName;
+        uint _cSale = shareOwnership[_sellerIndex].isCommonShare[true].sharesForSale;
+        uint _pSale = shareOwnership[_sellerIndex].isCommonShare[false].sharesForSale;
+        if (_cSale > 0) {
+            _commonSharesSelling = _cSale;
+            uint _cPriceFormatted = shareOwnership[_sellerIndex].isCommonShare[true].shareSalePrice;
+            uint _cLCD = lowestCommonDenominatorPrice(_cPriceFormatted);
+            _commonSharesPrice = _cPriceFormatted / _cLCD;
+            _commonSharePriceUnits = lowestCommonDenominatorString(_cLCD);
+        }
+        if (_pSale > 0) {
+            _preferredSharesSelling = _pSale;
+            uint _pPriceFormatted = shareOwnership[_sellerIndex].isCommonShare[false].shareSalePrice;
+            uint _pLCD = lowestCommonDenominatorPrice(_pPriceFormatted);
+            _preferredSharesPrice = _pPriceFormatted / _pLCD;
+            _preferredSharePriceUnits = lowestCommonDenominatorString(_pLCD);
+        }
+    }
+    
     //getPendingShares.
     
     function nameCompany(string _name) onlyowner {
@@ -156,17 +276,7 @@ contract Company {
     }
     
     function setNewShareValue(uint _val, string _unit) {
-        uint _newValue = _val;
-        
-        //Ensures minimum of a szabo is suggested as share value
-        if (stringsEqual(_unit, "szabo"))
-            _newValue *= 1 szabo;
-        else if (stringsEqual(_unit, "finney"))
-            _newValue *= 1 finney;
-        else if (stringsEqual(_unit, "ether"))
-            _newValue *= 1 ether;
-        else
-            throw;
+        uint _newValue = _val * currencyCheck(_unit);
             
         uint _ownerIndex = checkIfAlreadyOwner(msg.sender);
         if (_ownerIndex > shareOwnership.length)
@@ -230,6 +340,40 @@ contract Company {
             _voteTotal += votingFor[_votingFor].ownerAddress[_voterArray[i]].subject[_subject].sharesVotingFor;
         }
         return _voteTotal;
+    }
+    
+    function currencyCheck(string _unit) private returns (uint) {
+        if (stringsEqual(_unit, "szabo"))
+            return 1 szabo;
+        else if (stringsEqual(_unit, "finney"))
+            return 1 finney;
+        else if (stringsEqual(_unit, "ether"))
+            return 1 ether;
+        else if (stringsEqual(_unit, "wei"))
+            return 1 wei;
+        else
+            throw;
+    }
+    
+    function lowestCommonDenominatorPrice(uint _price) private returns (uint) {
+        uint64[4] memory priceArray = [1 ether, 1 finney, 1 szabo, 1 wei];
+        for (uint i = 0; i < priceArray.length; i++) 
+            if (_price / priceArray[i] > 0)
+                return priceArray[i];
+            
+        throw;
+    }
+    
+    function lowestCommonDenominatorString(uint _unit) private returns (string) {
+        uint64[4] memory priceArray = [1 ether, 1 finney, 1 szabo, 1 wei];
+        if (_unit / priceArray[0] == 1)
+            return "ether";
+        else if (_unit / priceArray[1] == 1)
+            return "finney";
+        else if (_unit /priceArray[2] == 1)
+            return "szabo";
+        else
+            return "wei";
     }
 
 	function stringsEqual(string _a, string _b) private returns (bool) {


### PR DESCRIPTION
1. Added a built-in exchange system, whereby shareholders can sell a chosen number of shares for a certain price of their choosing.

One can see which addresses are selling through JSON interface.

When buyer finds a satisfactory offer, they may buy those shares, and the contract automatically exchanges the ether for shares between the accounts. 

Code Caveats - atm, there need to be at least 2 addresses in the ownership array for this to work. Will be fixed after optimization stage
1. Another feature now is share transfer. You may simply transfer shares to any other owner now, if you partake in a exchange for these shares outside the contract. 
2. Added more helper functions, to simplify and streamline numbers, such as identifying when to display a certain amount of wei as ether, finney, or szabo, with the corresponding string.
